### PR TITLE
Fixed linker errors

### DIFF
--- a/include/cinject/cinject.h
+++ b/include/cinject/cinject.h
@@ -1,3 +1,6 @@
+#pragma once
+#ifndef Q_MOC_RUN //guard to prevent Qt moc processing of this file
+
 #include <typeinfo>
 #include <vector>
 #include <functional>
@@ -115,7 +118,7 @@ static component_type make_component_type(const std::string& customName = "")
     return component_type(typeid(T), customName);
 }
 
-bool operator==(const component_type& first, const component_type& other)
+inline bool operator==(const component_type& first, const component_type& other)
 {
     return first.typeInfo == other.typeInfo;
 }
@@ -723,7 +726,7 @@ std::shared_ptr<TInterface>>::type Container::get(InjectionContext* context)
 }
 
 
-void Container::findInstanceRetrievers(std::vector<std::shared_ptr<IInstanceRetriever>>& instanceRetrievers, const component_type& type) const
+inline void Container::findInstanceRetrievers(std::vector<std::shared_ptr<IInstanceRetriever>>& instanceRetrievers, const component_type& type) const
 {
     auto iter = registrations_.find(type);
     if (iter != registrations_.end())
@@ -741,3 +744,4 @@ void Container::findInstanceRetrievers(std::vector<std::shared_ptr<IInstanceRetr
 
 
 }
+#endif

--- a/include/cinject/cinject.h
+++ b/include/cinject/cinject.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifndef Q_MOC_RUN //guard to prevent Qt moc processing of this file
 
 #include <typeinfo>
 #include <vector>
@@ -744,4 +743,3 @@ inline void Container::findInstanceRetrievers(std::vector<std::shared_ptr<IInsta
 
 
 }
-#endif


### PR DESCRIPTION
Fixed following issues:
- Added missing #pragma once to guard against multiple includes in the same translation unit
- Fixed Qt moc handling of cinject.h by disabling its processing of the file
- Fixed two linker errors due to two inline methods (one free function and one method) defined outside of class scope that were not marked as inline - that caused multiply defined symbols when cinject.h was used in more than one translation unit file (see https://stackoverflow.com/questions/1568807/how-to-define-non-method-functions-in-header-libraries)